### PR TITLE
mali_kbase_core_linux: fix build failure with linux version >= 5.15

### DIFF
--- a/r8p0/drivers/gpu/arm/midgard/mali_kbase_core_linux.c
+++ b/r8p0/drivers/gpu/arm/midgard/mali_kbase_core_linux.c
@@ -4913,6 +4913,9 @@ module_exit(kbase_driver_exit);
 
 #endif /* CONFIG_OF */
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)
+MODULE_IMPORT_NS(DMA_BUF);
+#endif
 MODULE_LICENSE("GPL");
 MODULE_VERSION(MALI_RELEASE_NAME " (UK version " \
 		__stringify(BASE_UK_VERSION_MAJOR) "." \


### PR DESCRIPTION
Since Linux 5.15 module using DMA_BUF needs to explictly MODULE_IMPORT_NS
it, so let's add MODULE_IMPORT_NS(DMA_BUF); if Linux version is >= 5.15.0.

Signed-off-by: Giulio Benetti <giulio.benetti@benettiengineering.com>